### PR TITLE
[KOGITO-5768] Support PostgreSQL persistence in Helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.tgz
+
+*-values.yaml
+commit-msg.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Kogito Helm Charts
+This repository contains a collection of Helm charts to deploy various Kogito applications with different 
+infrastructure requirements. 
+
+# Usage
+By default, each chart will deploy a specific [Kogito example](https://github.com/kiegroup/kogito-examples) 
+where the chart will deploy any required infrastructure. Each chart's usage section will assume you have the 
+following setup:
+```sh
+kubectl create namespace kogito-helm
+git clone https://github.com/Kevin-Mok/kogito-helm-charts.git
+cd kogito-helm-charts
+export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+kubectl config set-context --current --namespace=kogito-helm
+```
+
+## Customizing Values
+To change the image deployed or any of the other default 
+values specified in [values.yaml](values.yaml), you can 
+simply create another values file and run `helm install` 
+with the `--values` flag and your values file name. For example:
+```sh
+cat << EOF > myvals.yaml
+runtime: springboot
+image:
+  repository: quay.io/kmok/process-springboot-example
+EOF
+helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
+```
+
+Or in the case like this one where you only have a couple 
+values to change, you can also specify values directly in 
+the command like so:
+```sh
+helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
+```
+
+# Applications Exposed By Default
+For ease of use and demonstration purposes, the Kogito application will be exposed with a `NodePort` by default and uses port 32000.
+
+# Road Map
+## Operator-Less
+- PostgreSQL (WIP)
+- Kafka
+- data index (requires 2 above)
+
+## With Operator
+- ~~Prometheus~~
+- Infinispan (WIP)
+- Kafka (WIP)
+- data index (requires 2 above)

--- a/kogito-basic/.gitignore
+++ b/kogito-basic/.gitignore
@@ -1,1 +1,0 @@
-*-values.yaml

--- a/kogito-basic/Chart.yaml
+++ b/kogito-basic/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kogito-basic/README.md
+++ b/kogito-basic/README.md
@@ -1,60 +1,11 @@
-# Kogito Helm Chart
+# Kogito Basic Helm Chart
 This is a Helm chart to deploy a Kogito application with no frills. 
 
 # Example Usage
-By default, this will deploy the basic Kogito [travel agency 
-example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/basic) 
+By default, this will deploy the basic Kogito [process-quarkus-example](https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example) 
 image which I have uploaded onto 
-[Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). 
+[Quay](https://quay.io/repository/kmok/process-quarkus-example?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-kubectl create namespace kogito-helm
-git clone https://github.com/Kevin-Mok/kogito-helm-chart.git
-helm install --namespace kogito-helm travel-agency-basic kogito-helm-chart
-export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
-curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "http://$NODE_INTERNAL_IP:32000/travels" -d @- << EOF
-{
-  "traveller" : {
-    "firstName" : "John",
-    "lastName" : "Doe",
-    "email" : "john.doe@example.com",
-    "nationality" : "American",
-    "address" : {
-      "street" : "main street",
-      "city" : "Boston",
-      "zipCode" : "10005",
-      "country" : "US"
-    }
-  },
-  "trip" : {
-    "city" : "New York",
-    "country" : "US",
-    "begin" : "2019-12-10T00:00:00.000+02:00",
-    "end" : "2019-12-15T00:00:00.000+02:00"
-  }
-}
-EOF
+helm install process-quarkus-example kogito-basic
+curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : false}}' -H "Content-Type: application/json" -X POST http://$NODE_INTERNAL_IP:32000/orders
 ```
-
-## Customizing Values
-To change the image deployed or any of the other default 
-values specified in [values.yaml](values.yaml), you can 
-simply create another values file and run `helm install` 
-with the `--values` flag and your values file name. For example:
-```sh
-cat << EOF > myvals.yaml
-runtime: springboot
-image:
-  repository: quay.io/kmok/process-springboot-example
-EOF
-helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
-```
-
-Or in the case like this one where you only have a couple 
-values to change, you can also specify values directly in 
-the command like so:
-```sh
-helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
-```
-
-# Applications Exposed By Default
-For ease of use and demonstration purposes, the Kogito application will be exposed with a `NodePort` by default and uses port 32000.

--- a/kogito-basic/values.yaml
+++ b/kogito-basic/values.yaml
@@ -7,9 +7,8 @@ replicaCount: 1
 runtime: quarkus
 
 image:
-  # repository: quay.io/kmok/process-quarkus-example
+  repository: quay.io/kmok/process-quarkus-example
   # repository: quay.io/kmok/process-springboot-example
-  repository: quay.io/kmok/kogito-travel-agency-basic
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/kogito-postgresql/.gitignore
+++ b/kogito-postgresql/.gitignore
@@ -1,1 +1,0 @@
-*-values.yaml

--- a/kogito-postgresql/.gitignore
+++ b/kogito-postgresql/.gitignore
@@ -1,0 +1,1 @@
+*-values.yaml

--- a/kogito-postgresql/.helmignore
+++ b/kogito-postgresql/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kogito-postgresql/Chart.lock
+++ b/kogito-postgresql/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.8.0
+digest: sha256:4867d27a33a0ebcf8d729ba4bd480fb74723fd66d105de0e2dec7292f952c112
+generated: "2021-07-29T00:45:56.025744335-04:00"

--- a/kogito-postgresql/Chart.yaml
+++ b/kogito-postgresql/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kogito-app
+description: A Helm chart for a Kogito application.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.3.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.8.0"

--- a/kogito-postgresql/Chart.yaml
+++ b/kogito-postgresql/Chart.yaml
@@ -15,10 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.8.0"
+
+dependencies:
+- name: postgresql
+  version: "10.8.0"
+  repository: "https://charts.bitnami.com/bitnami"

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -1,0 +1,60 @@
+# Kogito Helm Chart
+This is a Helm chart to deploy a Kogito application with no frills. 
+
+# Example Usage
+By default, this will deploy the basic Kogito [travel agency 
+example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/basic) 
+image which I have uploaded onto 
+[Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). 
+```sh
+kubectl create namespace kogito-helm
+git clone https://github.com/Kevin-Mok/kogito-helm-chart.git
+helm install --namespace kogito-helm travel-agency-basic kogito-helm-chart
+export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "http://$NODE_INTERNAL_IP:32000/travels" -d @- << EOF
+{
+  "traveller" : {
+    "firstName" : "John",
+    "lastName" : "Doe",
+    "email" : "john.doe@example.com",
+    "nationality" : "American",
+    "address" : {
+      "street" : "main street",
+      "city" : "Boston",
+      "zipCode" : "10005",
+      "country" : "US"
+    }
+  },
+  "trip" : {
+    "city" : "New York",
+    "country" : "US",
+    "begin" : "2019-12-10T00:00:00.000+02:00",
+    "end" : "2019-12-15T00:00:00.000+02:00"
+  }
+}
+EOF
+```
+
+## Customizing Values
+To change the image deployed or any of the other default 
+values specified in [values.yaml](values.yaml), you can 
+simply create another values file and run `helm install` 
+with the `--values` flag and your values file name. For example:
+```sh
+cat << EOF > myvals.yaml
+runtime: springboot
+image:
+  repository: quay.io/kmok/process-springboot-example
+EOF
+helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
+```
+
+Or in the case like this one where you only have a couple 
+values to change, you can also specify values directly in 
+the command like so:
+```sh
+helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
+```
+
+# Applications Exposed By Default
+For ease of use and demonstration purposes, the Kogito application will be exposed with a `NodePort` by default and uses port 32000.

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -1,60 +1,13 @@
-# Kogito Helm Chart
-This is a Helm chart to deploy a Kogito application with no frills. 
+# Kogito PostgreSQL Helm Chart
+This is a Helm chart to deploy a Kogito application with PostgreSQL 
+persistence. 
 
 # Example Usage
-By default, this will deploy the basic Kogito [travel agency 
-example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/basic) 
+By default, this will deploy the Kogito [process-postgresql-persistence-quarkus](https://github.com/kiegroup/kogito-examples/tree/stable/process-postgresql-persistence-quarkus) 
 image which I have uploaded onto 
-[Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). 
+[Quay](https://quay.io/repository/kmok/process-postgresql-persistence-quarkus?tab=tags). The 
+image is compiled using the `jdbc-persistence`. Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-kubectl create namespace kogito-helm
-git clone https://github.com/Kevin-Mok/kogito-helm-chart.git
-helm install --namespace kogito-helm travel-agency-basic kogito-helm-chart
-export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
-curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "http://$NODE_INTERNAL_IP:32000/travels" -d @- << EOF
-{
-  "traveller" : {
-    "firstName" : "John",
-    "lastName" : "Doe",
-    "email" : "john.doe@example.com",
-    "nationality" : "American",
-    "address" : {
-      "street" : "main street",
-      "city" : "Boston",
-      "zipCode" : "10005",
-      "country" : "US"
-    }
-  },
-  "trip" : {
-    "city" : "New York",
-    "country" : "US",
-    "begin" : "2019-12-10T00:00:00.000+02:00",
-    "end" : "2019-12-15T00:00:00.000+02:00"
-  }
-}
-EOF
+helm install process-postgresql-persistence-quarkus kogito-postgresql
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$NODE_INTERNAL_IP:32000/deals
 ```
-
-## Customizing Values
-To change the image deployed or any of the other default 
-values specified in [values.yaml](values.yaml), you can 
-simply create another values file and run `helm install` 
-with the `--values` flag and your values file name. For example:
-```sh
-cat << EOF > myvals.yaml
-runtime: springboot
-image:
-  repository: quay.io/kmok/process-springboot-example
-EOF
-helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
-```
-
-Or in the case like this one where you only have a couple 
-values to change, you can also specify values directly in 
-the command like so:
-```sh
-helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
-```
-
-# Applications Exposed By Default
-For ease of use and demonstration purposes, the Kogito application will be exposed with a `NodePort` by default and uses port 32000.

--- a/kogito-postgresql/templates/NOTES.txt
+++ b/kogito-postgresql/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kogito-app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kogito-app.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kogito-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kogito-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/kogito-postgresql/templates/_helpers.tpl
+++ b/kogito-postgresql/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kogito-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kogito-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kogito-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kogito-app.labels" -}}
+helm.sh/chart: {{ include "kogito-app.chart" . }}
+{{ include "kogito-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kogito-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kogito-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kogito-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kogito-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kogito-postgresql/templates/configmap.yaml
+++ b/kogito-postgresql/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.postgresqlConfigMap }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+data:
+  QUARKUS_DATASOURCE_DB-KIND: postgresql
+  QUARKUS_DATASOURCE_USERNAME: kogito-user
+  QUARKUS_DATASOURCE_PASSWORD: kogito-pass
+  QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/kogito

--- a/kogito-postgresql/templates/deployment.yaml
+++ b/kogito-postgresql/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.postgresqlConfigMap }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kogito-postgresql/templates/deployment.yaml
+++ b/kogito-postgresql/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kogito-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kogito-app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kogito-app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              {{- if eq .Values.runtime "quarkus" }}
+              path: /q/health/live
+              {{- else if eq .Values.runtime "springboot" }}
+              path: /actuator/health/liveness
+              {{- end }}
+              port: http
+          readinessProbe:
+            httpGet:
+              {{- if eq .Values.runtime "quarkus" }}
+              path: /q/health/ready
+              {{- else if eq .Values.runtime "springboot" }}
+              path: /actuator/health/readiness
+              {{- end }}
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/kogito-postgresql/templates/hpa.yaml
+++ b/kogito-postgresql/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kogito-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/kogito-postgresql/templates/ingress.yaml
+++ b/kogito-postgresql/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kogito-app.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/kogito-postgresql/templates/service.yaml
+++ b/kogito-postgresql/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kogito-app.fullname" . }}-np
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      nodePort: {{ .Values.service.nodePort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "kogito-app.selectorLabels" . | nindent 4 }}

--- a/kogito-postgresql/templates/serviceaccount.yaml
+++ b/kogito-postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kogito-app.serviceAccountName" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kogito-postgresql/templates/tests/test-connection.yaml
+++ b/kogito-postgresql/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kogito-app.fullname" . }}-test-connection"
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "kogito-app.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -1,0 +1,91 @@
+# Default values for kogito-app.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+runtime: quarkus
+
+image:
+  # repository: quay.io/kmok/process-quarkus-example
+  # repository: quay.io/kmok/process-springboot-example
+  repository: quay.io/kmok/kogito-travel-agency-basic
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# service:
+  # type: ClusterIP
+  # port: 80
+service:
+  type: NodePort
+  port: 8080
+  nodePort: 32000
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -7,12 +7,10 @@ replicaCount: 1
 runtime: quarkus
 
 image:
-  # repository: quay.io/kmok/process-quarkus-example
-  # repository: quay.io/kmok/process-springboot-example
-  repository: quay.io/kmok/kogito-travel-agency-basic
+  repository: quay.io/vajain/process-postgresql-persistence-quarkus
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "jdbc"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -89,3 +87,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+postgresqlConfigMap: postgresql-jdbc
+
+postgresql:
+  initdbScripts:
+    init.sql: |
+      CREATE ROLE "kogito-user" WITH LOGIN SUPERUSER INHERIT CREATEDB CREATEROLE NOREPLICATION ENCRYPTED PASSWORD 'md54adb613a8ffdd707e032c918d791e2e5';
+      CREATE DATABASE kogito WITH OWNER = "kogito-user" ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TABLESPACE = pg_default CONNECTION LIMIT = -1;

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -7,7 +7,8 @@ replicaCount: 1
 runtime: quarkus
 
 image:
-  repository: quay.io/vajain/process-postgresql-persistence-quarkus
+  # repository: quay.io/vajain/process-postgresql-persistence-quarkus
+  repository: quay.io/kmok/process-postgresql-persistence-quarkus
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "jdbc"

--- a/kogito-prometheus-operator/.gitignore
+++ b/kogito-prometheus-operator/.gitignore
@@ -1,1 +1,0 @@
-*-values.yaml

--- a/kogito-prometheus-operator/Chart.yaml
+++ b/kogito-prometheus-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kogito-prometheus-operator/README.md
+++ b/kogito-prometheus-operator/README.md
@@ -1,16 +1,26 @@
 # Kogito Helm Chart
 This is a Helm chart to deploy a Kogito application with Prometheus integration. 
 
+# Prometheus Integration
+Prometheus monitoring for this chart is enabled by default. As such, a 
+Prometheus instance will be created upon installation given 
+that the Prometheus operator is installed. If not installed, 
+please see the [Prometheus operator README](https://github.com/prometheus-operator/prometheus-operator#quickstart) 
+for instructions on installing the operator. Note that their 
+`bundle.yaml` defaults to installing in the `default` 
+namespace.
+
+You can access the web console at `http://$NODE_INTERNAL_IP:32001/graph` following the [Example Usage](#example-usage) above.
+
+To disable the Prometheus integration, you can set the `Values.prometheus.enabled` to `false`. 
+
 # Example Usage
 By default, this will deploy the basic Kogito [travel agency 
 example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/basic) 
 image which I have uploaded onto 
-[Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). 
+[Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-kubectl create namespace kogito-helm
-git clone https://github.com/Kevin-Mok/kogito-helm-chart.git
-helm install --namespace kogito-helm travel-agency-basic kogito-helm-chart
-export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+helm install travel-agency-basic kogito-prometheus-operator
 curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "http://$NODE_INTERNAL_IP:32000/travels" -d @- << EOF
 {
   "traveller" : {
@@ -35,53 +45,7 @@ curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "
 EOF
 ```
 
-## Customizing Values
-To change the image deployed or any of the other default 
-values specified in [values.yaml](values.yaml), you can 
-simply create another values file and run `helm install` 
-with the `--values` flag and your values file name. For example:
-```sh
-cat << EOF > myvals.yaml
-runtime: springboot
-image:
-  repository: quay.io/kmok/process-springboot-example
-EOF
-helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
-```
-
-Or in the case like this one where you only have a couple 
-values to change, you can also specify values directly in 
-the command like so:
-```sh
-helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
-```
-
 # Applications Exposed By Default
 For ease of use and demonstration purposes, both the Kogito application and Prometheus 
 instance will be exposed with `NodePort`'s by default; they use ports 32000 
 and 32001 respectively.
-
-# Prometheus Integration
-Prometheus monitoring is enabled by default. As such, a 
-Prometheus instance will be created upon installation given 
-that the Prometheus operator is installed. If not installed, 
-please see the [Prometheus operator README](https://github.com/prometheus-operator/prometheus-operator#quickstart) 
-for instructions on installing the operator. Note that their 
-`bundle.yaml` defaults to installing in the `default` 
-namespace.
-
-You can access the web console at `http://$NODE_INTERNAL_IP:32001/graph` following the [Example Usage](#example-usage) above.
-
-To disable the Prometheus integration, you can set the `Values.prometheus.enabled` to `false`. 
-
-# Road Map
-## Operator-Less
-- PostgreSQL (WIP)
-- Kafka
-- data index (requires 2 above)
-
-## With Operator
-- ~~Prometheus~~
-- Infinispan (WIP)
-- Kafka (WIP)
-- data index (requires 2 above)

--- a/kogito-prometheus-operator/values.yaml
+++ b/kogito-prometheus-operator/values.yaml
@@ -7,8 +7,6 @@ replicaCount: 1
 runtime: quarkus
 
 image:
-  # repository: quay.io/kmok/process-quarkus-example
-  # repository: quay.io/kmok/process-springboot-example
   repository: quay.io/kmok/kogito-travel-agency-basic
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5768

This chart allows users to deploy a Kogito application with PostgreSQL persistence. It deploys the [process-postgresql-persistence-quarkus example](https://github.com/kiegroup/kogito-examples/tree/stable/process-postgresql-persistence-quarkus) by default.
