### PR TITLE
[KOGITO-5770] Create Helm chart repository

### DIFF
--- a/.github/workflows/helm-publisher.yaml
+++ b/.github/workflows/helm-publisher.yaml
@@ -1,0 +1,15 @@
+name: helm-publisher
+on:
+  push:
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.log
-*.tgz
+*/*/*.tgz
 
 *-values.yaml
 commit-msg.txt

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ By default, each chart will deploy a specific [Kogito example](https://github.co
 where the chart will deploy any required infrastructure. Each chart's usage section will assume you have the 
 following setup:
 ```sh
+helm repo add kogito https://kiegroup.github.io/kogito-helm-charts
 kubectl create namespace kogito-helm
-git clone https://github.com/Kevin-Mok/kogito-helm-charts.git
-cd kogito-helm-charts
 export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
 kubectl config set-context --current --namespace=kogito-helm
 ```

--- a/kogito-basic/Chart.yaml
+++ b/kogito-basic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: kogito-app
-description: A Helm chart for a Kogito application.
+name: kogito-basic
+description: A Helm chart for a basic Kogito application.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/kogito-basic/README.md
+++ b/kogito-basic/README.md
@@ -6,6 +6,6 @@ By default, this will deploy the basic Kogito [process-quarkus-example](https://
 image which I have uploaded onto 
 [Quay](https://quay.io/repository/kmok/process-quarkus-example?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-helm install process-quarkus-example kogito-basic
+helm install process-quarkus-example kogito/kogito-basic
 curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : false}}' -H "Content-Type: application/json" -X POST http://$NODE_INTERNAL_IP:32000/orders
 ```

--- a/kogito-kafka/Chart.yaml
+++ b/kogito-kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: kogito-app
-description: A Helm chart for a Kogito application.
+name: kogito-kafka
+description: A Helm chart for a Kogito application with a Kafka dependency.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/kogito-kafka/README.md
+++ b/kogito-kafka/README.md
@@ -7,7 +7,7 @@ By default, this will deploy the Kogito [process-kafka-quickstart-quarkus](https
 image which I have uploaded onto 
 [Quay](https://quay.io/repository/kmok/process-kafka-quickstart-quarkus?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-helm install process-kafka-quickstart-quarkus kogito-kafka --render-subchart-notes
+helm install process-kafka-quickstart-quarkus kogito/kogito-kafka --render-subchart-notes
 kubectl run process-kafka-quickstart-quarkus-kafka-client --restart='Never' --image docker.io/bitnami/kafka:2.8.0-debian-10-r57 --command -- sleep infinity  
 kubectl exec --tty -i process-kafka-quickstart-quarkus-kafka-client -- bash
 kafka-console-producer.sh \

--- a/kogito-postgresql/Chart.yaml
+++ b/kogito-postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: kogito-app
-description: A Helm chart for a Kogito application.
+name: kogito-postgresql
+description: A Helm chart for a Kogito application with a PostgreSQL dependency.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -8,7 +8,7 @@ image which I have uploaded onto
 [Quay](https://quay.io/repository/kmok/process-postgresql-persistence-quarkus?tab=tags). The 
 image is compiled using the `jdbc-persistence`. Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-helm install process-postgresql-persistence-quarkus kogito-postgresql
+helm install process-postgresql-persistence-quarkus kogito/kogito-postgresql
 curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$NODE_INTERNAL_IP:32000/deals
 ```
 

--- a/kogito-prometheus-operator/Chart.yaml
+++ b/kogito-prometheus-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: kogito-app
-description: A Helm chart for a Kogito application.
+name: kogito-prometheus-operator
+description: A Helm chart for a Kogito application with integration with the Prometheus operator.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/kogito-prometheus-operator/README.md
+++ b/kogito-prometheus-operator/README.md
@@ -20,7 +20,7 @@ example](https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-a
 image which I have uploaded onto 
 [Quay](https://quay.io/repository/kmok/kogito-travel-agency-basic?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
 ```sh
-helm install travel-agency-basic kogito-prometheus-operator
+helm install travel-agency-basic kogito/kogito-prometheus-operator
 curl -H "Content-Type: application/json" -H "Accept: application/json" -X POST "http://$NODE_INTERNAL_IP:32000/travels" -d @- << EOF
 {
   "traveller" : {


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5770

This PR adds [this GitHub Action](https://github.com/stefanprodan/helm-gh-pages) to create a Helm chart repository on GitHub Pages. The charts are packaged automatically on each release, and the documentation is updated to reflect the usage of the repository.
