### PR TITLE
[KOGITO-5775] PSQL table doesn't exist upon deployment in Helm

### DIFF
--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -12,11 +12,18 @@ helm install process-postgresql-persistence-quarkus kogito/kogito-postgresql
 curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$NODE_INTERNAL_IP:32000/deals
 ```
 
-# `init.sql`
+# PostgreSQL Setup
 This chart uses Bitnami's [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) 
-to setup the PostgreSQL instance and 
-initializes a database for the Kogito [process-postgresql-persistence-quarkus 
-example](https://github.com/kiegroup/kogito-examples/tree/stable/process-postgresql-persistence-quarkus) 
+to setup the PostgreSQL instance.
+Customization of the PostgreSQL instance can be done 
+with their parameters listed in [Bitnami's README](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#parameters) 
+via the same process of adding the parameters to a custom 
+YAML file and passing it into `helm install --values`.
+
+# `init.sql`
+This chart initializes a database for the Kogito [process-postgresql-persistence-quarkus 
+example](https://github.com/kiegroup/kogito-examples/tree/stable/process-postgresql-persistence-quarkus) by 
+default
 by passing in an SQL script in `values.yaml`:
 ```yaml
 postgresql:
@@ -33,7 +40,33 @@ For example:
 helm install --values sql-script.yaml process-postgresql-persistence-quarkus kogito-postgresql
 ```
 
-More customization of the PostgreSQL instance can be done 
-with their parameters listed in [Bitnami's README](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#parameters) 
-via the same process of adding the parameters to a custom 
-YAML file and passing it into `helm install --values`.
+## Concurrency Issues
+Since the Kogito application and PostgreSQL instance are 
+started at the same time, concurrency issues can occur when 
+the Kogito application expects the database to be ready when 
+it is not.
+
+### Health Check
+Integrating something like the [SmallRye 
+Health extension](https://quarkus.io/guides/smallrye-health) 
+for a Quarkus Kogito application is strongly recommended. In 
+the SmallRye Health documentation, they show how you can 
+implement a [readiness health check 
+procedure](https://quarkus.io/guides/smallrye-health#adding-a-readiness-health-check-procedure) 
+for a database connection. This way, the pod will not accept 
+traffic until a connection to the database is established.
+
+### Initializing Necessary Tables
+Another concurrency issue that can arise is when the Kogito 
+application only creates its necessary tables on startup 
+(see [KOGITO-5775](https://issues.redhat.com/browse/KOGITO-5775)). 
+In this scenario, even after a connection to the database is established, 
+the Kogito application will try to insert a row into a 
+non-existent table. There are 2 possible solutions to this 
+problem:
+1. In the Kogito application's code, check if the table 
+exists before inserting into it. If it does not exist, 
+create it first.
+2. Initialize the table in `init.sql` as a value as 
+described in [the section above](#init.sql). This is the 
+method used for the default example in this chart.

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -96,3 +96,6 @@ postgresql:
     init.sql: |
       CREATE ROLE "kogito-user" WITH LOGIN SUPERUSER INHERIT CREATEDB CREATEROLE NOREPLICATION ENCRYPTED PASSWORD 'md54adb613a8ffdd707e032c918d791e2e5';
       CREATE DATABASE kogito WITH OWNER = "kogito-user" ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TABLESPACE = pg_default CONNECTION LIMIT = -1;
+      CREATE TABLE public.process_instances ( id uuid NOT NULL, payload bytea NOT NULL, process_id character varying NOT NULL, version bigint);
+      ALTER TABLE public.process_instances OWNER TO "kogito-user";
+      ALTER TABLE ONLY public.process_instances ADD CONSTRAINT process_instances_pkey PRIMARY KEY (id);


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5775

This PR initializes the table needed for the process-postgresql-persistence-quarkus example to fix the concurrency issue described in the Jira as well documents the concurrency issues you can face with PostgreSQL and solutions.
