### PR TITLE
[KOGITO-5772] Set up routes in Helm for applications by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ following setup:
 ```sh
 helm repo add kogito https://kiegroup.github.io/kogito-helm-charts
 kubectl create namespace kogito-helm
-export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
 kubectl config set-context --current --namespace=kogito-helm
 ```
 

--- a/kogito-basic/README.md
+++ b/kogito-basic/README.md
@@ -4,8 +4,23 @@ This is a Helm chart to deploy a Kogito application with no frills.
 # Example Usage
 By default, this will deploy the basic Kogito [process-quarkus-example](https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example) 
 image which I have uploaded onto 
-[Quay](https://quay.io/repository/kmok/process-quarkus-example?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands:
+[Quay](https://quay.io/repository/kmok/process-quarkus-example?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands 
+in the base directory of the repository:
+## OpenShift
 ```sh
 helm install process-quarkus-example kogito/kogito-basic
-curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : false}}' -H "Content-Type: application/json" -X POST http://$NODE_INTERNAL_IP:32000/orders
+export KOGITO_URL=$(kubectl get routes -o jsonpath="{.items[?(@.metadata.name=='process-quarkus-example')].spec.host}")
 ```
+
+## Other (e.g. minikube)
+```sh
+helm install --set openshift=false process-quarkus-example kogito/kogito-basic
+export KOGITO_URL=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }'):32000
+```
+
+## Example Command
+```
+> curl -d '{"approver" : "john", "order" : {"orderNumber" : "12345", "shipped" : false}}' -H "Content-Type: application/json" -X POST http://$KOGITO_URL/orders
+{"id":"1c7790db-6900-44f0-884f-97a546405fbd","approver":"john","order":{"orderNumber":"12345","shipped":false,"total":0.5123325950331652}}
+```
+You can find other commands to run in [the example's README](https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example#example-usage).

--- a/kogito-basic/templates/NOTES.txt
+++ b/kogito-basic/templates/NOTES.txt
@@ -5,10 +5,9 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.openshift }}
+  kubectl get routes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[?(@.metadata.name=='{{ include "kogito-app.fullname" . }}')].spec.host}"
 {{- else if contains "NodePort" .Values.service.type }}
-  # if using CRC
-  export NODE_IP=$(crc ip)
-  # else
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:{{ .Values.service.nodePort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}

--- a/kogito-basic/templates/NOTES.txt
+++ b/kogito-basic/templates/NOTES.txt
@@ -6,9 +6,11 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kogito-app.fullname" . }})
+  # if using CRC
+  export NODE_IP=$(crc ip)
+  # else
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:{{ .Values.service.nodePort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kogito-app.fullname" . }}'

--- a/kogito-basic/templates/route.yaml
+++ b/kogito-basic/templates/route.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.openshift -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  port:
+    targetPort: {{ .Values.service.targetPort }}
+  to:
+    kind: Service
+    name: {{ include "kogito-app.fullname" . }}
+{{- end }}

--- a/kogito-basic/templates/service.yaml
+++ b/kogito-basic/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kogito-app.fullname" . }}-np
+  name: {{ include "kogito-app.fullname" . }}
   labels:
     {{- include "kogito-app.labels" . | nindent 4 }}
 spec:

--- a/kogito-basic/values.yaml
+++ b/kogito-basic/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+openshift: true
 runtime: quarkus
 
 image:

--- a/kogito-kafka/templates/NOTES.txt
+++ b/kogito-kafka/templates/NOTES.txt
@@ -5,10 +5,11 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.openshift }}
+  kubectl get routes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[?(@.metadata.name=='{{ include "kogito-app.fullname" . }}')].spec.host}"
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kogito-app.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:{{ .Values.service.nodePort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kogito-app.fullname" . }}'

--- a/kogito-kafka/templates/route.yaml
+++ b/kogito-kafka/templates/route.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.openshift -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  port:
+    targetPort: {{ .Values.service.targetPort }}
+  to:
+    kind: Service
+    name: {{ include "kogito-app.fullname" . }}
+{{- end }}

--- a/kogito-kafka/templates/service.yaml
+++ b/kogito-kafka/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kogito-app.fullname" . }}-np
+  name: {{ include "kogito-app.fullname" . }}
   labels:
     {{- include "kogito-app.labels" . | nindent 4 }}
 spec:

--- a/kogito-kafka/values.yaml
+++ b/kogito-kafka/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+openshift: true
 runtime: quarkus
 
 image:

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -6,10 +6,23 @@ persistence.
 By default, this will deploy the Kogito [process-postgresql-persistence-quarkus](https://github.com/kiegroup/kogito-examples/tree/stable/process-postgresql-persistence-quarkus) 
 image which I have uploaded onto 
 [Quay](https://quay.io/repository/kmok/process-postgresql-persistence-quarkus?tab=tags). The 
-image is compiled using the `jdbc-persistence`. Follow the [initial setup](../README.md#Usage), then run these commands:
+image is compiled using the `jdbc-persistence`. Follow the [initial setup](../README.md#Usage), then run these commands
+in the base directory of the repository:
+## OpenShift
 ```sh
 helm install process-postgresql-persistence-quarkus kogito/kogito-postgresql
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$NODE_INTERNAL_IP:32000/deals
+export KOGITO_URL=$(kubectl get routes -o jsonpath="{.items[?(@.metadata.name=='process-postgresql-persistence-quarkus')].spec.host}")
+```
+
+## Other (e.g. minikube)
+```sh
+helm install --set openshift=false process-postgresql-persistence-quarkus kogito/kogito-postgresql
+export KOGITO_URL=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }'):32000
+```
+
+## Expected Output
+```
+> curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$KOGITO_URL/deals
 ```
 
 # PostgreSQL Setup

--- a/kogito-postgresql/templates/NOTES.txt
+++ b/kogito-postgresql/templates/NOTES.txt
@@ -5,10 +5,11 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.openshift }}
+  kubectl get routes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[?(@.metadata.name=='{{ include "kogito-app.fullname" . }}')].spec.host}"
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kogito-app.fullname" . }})-np
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:{{ .Values.service.nodePort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kogito-app.fullname" . }}'

--- a/kogito-postgresql/templates/route.yaml
+++ b/kogito-postgresql/templates/route.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.openshift -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  port:
+    targetPort: {{ .Values.service.targetPort }}
+  to:
+    kind: Service
+    name: {{ include "kogito-app.fullname" . }}
+{{- end }}

--- a/kogito-postgresql/templates/service.yaml
+++ b/kogito-postgresql/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kogito-app.fullname" . }}-np
+  name: {{ include "kogito-app.fullname" . }}
   labels:
     {{- include "kogito-app.labels" . | nindent 4 }}
 spec:

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -100,3 +100,13 @@ postgresql:
       CREATE TABLE public.process_instances ( id uuid NOT NULL, payload bytea NOT NULL, process_id character varying NOT NULL, version bigint);
       ALTER TABLE public.process_instances OWNER TO "kogito-user";
       ALTER TABLE ONLY public.process_instances ADD CONSTRAINT process_instances_pkey PRIMARY KEY (id);
+  volumePermissions:
+    securityContext:
+      runAsUser: auto
+  securityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
+  shmVolume:
+    chmod:
+      enabled: false

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+openshift: true
 runtime: quarkus
 
 image:

--- a/kogito-prometheus-operator/templates/NOTES.txt
+++ b/kogito-prometheus-operator/templates/NOTES.txt
@@ -5,10 +5,11 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.openshift }}
+  kubectl get routes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[?(@.metadata.name=='{{ include "kogito-app.fullname" . }}')].spec.host}"
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kogito-app.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:{{ .Values.service.nodePort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kogito-app.fullname" . }}'

--- a/kogito-prometheus-operator/templates/route.yaml
+++ b/kogito-prometheus-operator/templates/route.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.openshift -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kogito-app.fullname" . }}
+  labels:
+    {{- include "kogito-app.labels" . | nindent 4 }}
+spec:
+  port:
+    targetPort: {{ .Values.service.targetPort }}
+  to:
+    kind: Service
+    name: {{ include "kogito-app.fullname" . }}
+{{- end }}

--- a/kogito-prometheus-operator/templates/service.yaml
+++ b/kogito-prometheus-operator/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kogito-app.fullname" . }}-np
+  name: {{ include "kogito-app.fullname" . }}
   labels:
     {{- include "kogito-app.labels" . | nindent 4 }}
 spec:

--- a/kogito-prometheus-operator/values.yaml
+++ b/kogito-prometheus-operator/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+openshift: true
 runtime: quarkus
 
 image:


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5772
https://issues.redhat.com/browse/KOGITO-5774

This PR introduces routes for the Helm charts to be exposed on OpenShift as well as fixes a deployment issue for the PSQL Helm chart on OpenShift.
