### PR TITLE
[KOGITO-5775] PSQL table doesn't exist upon deployment in Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with the `--values` flag and your values file name. For example:
 cat << EOF > myvals.yaml
 runtime: springboot
 image:
-  repository: quay.io/kmok/process-springboot-example
+  repository: quay.io/kiegroup/examples-process-springboot-example
 EOF
 helm install --namespace kogito-helm --values myvals.yaml process-springboot-example kogito-helm-chart
 ```
@@ -30,9 +30,9 @@ Or in the case like this one where you only have a couple
 values to change, you can also specify values directly in 
 the command like so:
 ```sh
-helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
+helm install --namespace kogito-helm --set image.repository=quay.io/kiegroup/examples-process-springboot-example,runtime=springboot process-springboot-example kogito-helm-chart
 ```
-
+Note that the default images used in the charts are quarkus examples.
 # Applications Exposed By Default
 For ease of use and demonstration purposes, the Kogito application will be exposed by default.
 On OpenShift, a `Route` is created by default to expose the application.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ helm install --namespace kogito-helm --set image.repository=quay.io/kmok/process
 ```
 
 # Applications Exposed By Default
-For ease of use and demonstration purposes, the Kogito application will be exposed with a `NodePort` by default and uses port 32000.
+For ease of use and demonstration purposes, the Kogito application will be exposed by default.
+On OpenShift, a `Route` is created by default to expose the application.
+On Kubernetes, the application is exposed with a `NodePort` by default and uses port 32000.
+
+Note that OpenShift Route hosts are limited to 63 characters, so long chart names may cause route creation issues.
 
 # Road Map
 ## Operator-Less

--- a/kogito-basic/README.md
+++ b/kogito-basic/README.md
@@ -4,7 +4,7 @@ This is a Helm chart to deploy a Kogito application with no frills.
 # Example Usage
 By default, this will deploy the basic Kogito [process-quarkus-example](https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example) 
 image which I have uploaded onto 
-[Quay](https://quay.io/repository/kmok/process-quarkus-example?tab=tags). Follow the [initial setup](../README.md#Usage), then run these commands 
+[Quay](https://quay.io/repository/kiegroup/examples-process-quarkus-example). Follow the [initial setup](../README.md#Usage), then run these commands 
 in the base directory of the repository:
 ## OpenShift
 ```sh

--- a/kogito-basic/values.yaml
+++ b/kogito-basic/values.yaml
@@ -8,8 +8,7 @@ openshift: true
 runtime: quarkus
 
 image:
-  repository: quay.io/kmok/process-quarkus-example
-  # repository: quay.io/kmok/process-springboot-example
+  repository: quay.io/kiegroup/examples-process-quarkus-example
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -54,7 +54,7 @@ For example:
 helm install --values sql-script.yaml process-postgresql-persistence-quarkus kogito-postgresql
 ```
 
-## Readiness Check
+## Race Condition Issues
 Since the Kogito application and PostgreSQL instance are 
 started at the same time, concurrency issues can occur when 
 the Kogito application expects the database to be ready when 

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -10,13 +10,13 @@ image is compiled using the `jdbc-persistence`. Follow the [initial setup](../RE
 in the base directory of the repository:
 ## OpenShift
 ```sh
-helm install process-postgresql-persistence-quarkus kogito/kogito-postgresql
-export KOGITO_URL=$(kubectl get routes -o jsonpath="{.items[?(@.metadata.name=='process-postgresql-persistence-quarkus')].spec.host}")
+helm install process-postgresql kogito/kogito-postgresql
+export KOGITO_URL=$(kubectl get routes -o jsonpath="{.items[?(@.metadata.name=='process-postgresql')].spec.host}")
 ```
 
 ## Other (e.g. minikube)
 ```sh
-helm install --set openshift=false process-postgresql-persistence-quarkus kogito/kogito-postgresql
+helm install --set openshift=false process-postgresql kogito/kogito-postgresql
 export KOGITO_URL=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }'):32000
 ```
 

--- a/kogito-postgresql/README.md
+++ b/kogito-postgresql/README.md
@@ -23,6 +23,7 @@ export KOGITO_URL=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses
 ## Expected Output
 ```
 > curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name" : "my fancy deal", "traveller" : { "firstName" : "John", "lastName" : "Doe", "email" : "jon.doe@example.com", "nationality" : "American","address" : { "street" : "main street", "city" : "Boston", "zipCode" : "10005", "country" : "US" }}}' http://$KOGITO_URL/deals
+{"id":"57233bda-ba20-4640-8ddd-650f16ce58b9","review":null,"name":"my fancy deal","traveller":{"firstName":"John","lastName":"Doe","email":"jon.doe@example.com","nationality":"American","address":{"street":"main street","city":"Boston","zipCode":"10005","country":"US"}}}
 ```
 
 # PostgreSQL Setup
@@ -53,33 +54,10 @@ For example:
 helm install --values sql-script.yaml process-postgresql-persistence-quarkus kogito-postgresql
 ```
 
-## Concurrency Issues
+## Readiness Check
 Since the Kogito application and PostgreSQL instance are 
 started at the same time, concurrency issues can occur when 
 the Kogito application expects the database to be ready when 
 it is not.
 
-### Health Check
-Integrating something like the [SmallRye 
-Health extension](https://quarkus.io/guides/smallrye-health) 
-for a Quarkus Kogito application is strongly recommended. In 
-the SmallRye Health documentation, they show how you can 
-implement a [readiness health check 
-procedure](https://quarkus.io/guides/smallrye-health#adding-a-readiness-health-check-procedure) 
-for a database connection. This way, the pod will not accept 
-traffic until a connection to the database is established.
-
-### Initializing Necessary Tables
-Another concurrency issue that can arise is when the Kogito 
-application only creates its necessary tables on startup 
-(see [KOGITO-5775](https://issues.redhat.com/browse/KOGITO-5775)). 
-In this scenario, even after a connection to the database is established, 
-the Kogito application will try to insert a row into a 
-non-existent table. There are 2 possible solutions to this 
-problem:
-1. In the Kogito application's code, check if the table 
-exists before inserting into it. If it does not exist, 
-create it first.
-2. Initialize the table in `init.sql` as a value as 
-described in [the section above](#init.sql). This is the 
-method used for the default example in this chart.
+To solve this issue, an `initContainers` is implemented to delay startup of the Kogito application until the database is ready to start receiving connections. 

--- a/kogito-postgresql/templates/_helpers.tpl
+++ b/kogito-postgresql/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the postgresql service name for readiness check.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains postgresql chart name it will be used as a full name.
+*/}}
+{{- define "kogito-app.postgresqlName" -}}
+{{- $name := "postgresql" }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/kogito-postgresql/templates/configmap.yaml
+++ b/kogito-postgresql/templates/configmap.yaml
@@ -8,4 +8,4 @@ data:
   QUARKUS_DATASOURCE_DB-KIND: postgresql
   QUARKUS_DATASOURCE_USERNAME: kogito-user
   QUARKUS_DATASOURCE_PASSWORD: kogito-pass
-  QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/kogito
+  QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://{{ include "kogito-app.postgresqlName" . }}:5432/kogito

--- a/kogito-postgresql/templates/deployment.yaml
+++ b/kogito-postgresql/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
       - name: init-postgres
         image: postgres
-        command: ['sh', '-c', 'until pg_isready --host={{ .Release.Name }}-postgresql --port=5432 --username=postgres; do echo waiting for postgresql; sleep 2; done;']
+        command: ['sh', '-c', 'until pg_isready --host={{ include "kogito-app.postgresqlName" . }} --port=5432 --username=postgres; do echo waiting for postgresql; sleep 2; done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/kogito-postgresql/templates/deployment.yaml
+++ b/kogito-postgresql/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       serviceAccountName: {{ include "kogito-app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      - name: init-postgres
+        image: postgres
+        command: ['sh', '-c', 'until pg_isready --host={{ .Release.Name }}-postgresql --port=5432 --username=postgres; do echo waiting for postgresql; sleep 2; done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/kogito-postgresql/values.yaml
+++ b/kogito-postgresql/values.yaml
@@ -8,7 +8,6 @@ openshift: true
 runtime: quarkus
 
 image:
-  # repository: quay.io/vajain/process-postgresql-persistence-quarkus
   repository: quay.io/kmok/process-postgresql-persistence-quarkus
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5775

This PR fixes the bug where PSQL table doesn't exist upon deployment in Helm due to concurrency issues between the Kogito Application and the PSQL database. 

## Solution
I implemented `initContainers` to block the Kogito Application startup until the database is ready to begin accepting connections. 

I also noticed due to Helm naming conventions, if the chart release name contains the chart name, the chart name is not included in the app fullname. Due to this naming convention, the psql database fails to be found at times using the default name. Thus, I defined a `kogito-app.postgresqlName` to ensure the templates use the same name we expect the bitnami postgresql chart.